### PR TITLE
zz login templates

### DIFF
--- a/templates/exploredata/login.html
+++ b/templates/exploredata/login.html
@@ -1,0 +1,208 @@
+{% extends "page.html" %}
+{% if announcement_login %}
+  {% set announcement = announcement_login %}
+{% endif %}
+
+{% block login_widget %}
+{% endblock %}
+
+{% block main %}
+
+<style>
+table, th, td {
+  border: 0px solid black;
+  border-collapse: collapse;
+}
+th, td {
+  padding: 10px 30px;
+  vertical-align: top;
+}
+.btn-jupyter, .btn-jupyter:active, .btn-jupyter:active:hover, .btn-jupyter:active:focus,
+.btn-jupyter:focus { background-color: #00abc9; border-color: rgba(0,171,201,0.85); }
+.btn-jupyter:hover { background: rgba(0,171,201,0.85); border-color: rgba(0,171,201,0.85); }
+.btn-jupyter:active { filter: brightness(85%); }
+
+.info-txt{
+  font-size: 14px;
+  font-family: “Open Sans”,sans-serif;
+  max-width: 800px;
+}
+
+.header{
+  height: 150px;
+  width: 100%;
+}
+.header-top {
+  position: absolute;
+  height: 72px;
+  left: 100px;
+  top: 100px;
+  border: 0px solid black;
+  z-index: 1;
+ }
+</style>
+
+<div>
+	<img class='header'src='https://www.icos-cp.eu/themes/cp_theme_d8/images/icos-header.jpg'>
+	<a href="https://www.icos-cp.eu/" >
+		<img class='header-top' src='https://www.icos-cp.eu/sites/default/files/ICOS-logo.svg'
+             alt='Home'>
+	</a>
+</div>
+<br>
+<table>
+	<tr><td colspan="3">
+
+{% block login %}
+
+<div >
+<form action="{{login_url}}?next={{next}}" method="post" role="form">
+  <div class='info-txt'>
+    <h2>Sign in to Exploredata</h2>
+  </div>
+  <div class='auth-form-body'>
+
+    <p id='insecure-login-warning' class='hidden'>
+    Warning: JupyterHub seems to be served over an unsecured HTTP connection.
+    We strongly recommend enabling HTTPS for JupyterHub.
+    </p>
+    </td></tr>
+    <tr><td width= '40%'>
+    {% if login_error %}
+    <p class="login_error">
+      {{login_error}}
+    </p>
+    {% endif %}
+    <label for="username_input">Username:</label>
+    <input
+      id="username_input"
+      type="text"
+      autocapitalize="off"
+      autocorrect="off"
+      class="form-control"
+      name="username"
+      val="{{username}}"
+      tabindex="1"
+      autofocus="autofocus"
+    />
+    <label for='password_input'>Password:</label>
+    <input
+      type="password"
+      class="form-control"
+      name="password"
+      id="password_input"
+      tabindex="2"
+    />
+    </td></tr>
+    <tr><td>
+    <input    
+      type="checkbox"      
+      name="licence"
+      id="licence_check"
+      onchange="document.getElementById('login_submit').disabled = !this.checked;"
+      tabindex="3"
+    />
+    <label for='licence'>
+    &nbsp I accept that ICOS data is under a<br>
+        <a href="https://data.icos-cp.eu/licence"
+           target="_blank">&nbsp CC BY 4.0 licence</a> &nbsp
+        <img src="https://www.icos-cp.eu/sites/default/files/inline-images/creativecommons.png">
+    </label>
+    </td><td>
+    <div class="feedback-container">
+      <input
+        id="login_submit"
+        type="submit"
+        class='btn btn-jupyter'
+        value='Sign In'
+        tabindex="4"
+        disabled='true'
+        />
+      <div class="feedback-widget hidden">
+        <i class="fa fa-spinner"></i>
+      </div>
+    </div>
+  </div>
+</form>
+
+</div>
+{% endblock login %}
+
+	</td>
+	<td width =200>&nbsp</td>
+	</tr>
+	<tr>
+	<td colspan="3">
+		<div class='info-txt'>
+			<p>This is a service from the ICOS Carbon Portal to showcase how Python Notebooks with
+                Jupyter can be used to access the ICOS data products. Please read our
+                <a href='https://icos-carbon-portal.github.io/jupyter/icos_notebooks/'
+                   target=_blank>Documentation</a>.
+                Once you log in, you will find the following structure with examples to play with:
+            </p>
+			<ul>
+			<li><b>Education:</b> includes notebooks that use ICOS data to introduce students to
+                basic principles of climate science and programming</li>
+			<li><b>ICOS Jupyter Notebooks:</b> contains notebooks processing and presenting ICOS
+                data in interactive visualizations</li>
+			<li><b>Introduction:</b> contains notebooks that quickly introduce the fundamental
+                principles of Python programming</li>
+			<li><b>Project-specific Jupyter Notebooks:</b> includes notebooks presenting the
+                scientific output of ICOS projects</li>
+			<li><b>pylib_examples:</b> includes notebooks with examples on using our 'icoscp'
+                python library to access ICOS data
+			<br>Source: <a href='https://github.com/ICOS-Carbon-Portal/pylib/' target=_blank>
+                    https://github.com/ICOS-Carbon-Portal/pylib/</a>
+            <br>Documentation <a href='https://icos-carbon-portal.github.io/pylib/' target=_blank>
+                    https://icos-carbon-portal.github.io/pylib/</a>
+			</li>
+			</ul>
+			</div>
+	</td></tr>
+	<tr ><td colspan="3">
+			<div class='info-txt'>
+			<p>Please be aware, that this service is <b>restricted</b>. We allow only a limited
+                amount of users to login and <b>data is not persistent</b>. After inactivity, you
+                will be logged out automatically. If you want to save a file you have
+                created/changed, you need to download the file to your computer.</p>
+
+            <p>If you are interested in using our Jupyter Notebook Service to do research with ICOS
+                data and elaborated products, please apply for a
+                <a href='https://www.icos-cp.eu/jupyter-personal-account-application'
+                   target=_blank>personal account</a>.
+            Project folders (collaboration space) allows groups of users to have a shared space
+                which is only visible to the members of the group.
+                <a href='https://www.icos-cp.eu/jupyter-collaboration-space-application'
+                   target=_blank>​Apply for collaborative space</a>.</br>
+                If you have a general question, email us to jupyter-info (at) icos-cp.eu.
+
+			<p>If you would like to explore the examples on your own computer, everything is public
+                available on
+			<a href='https://github.com/ICOS-Carbon-Portal/jupyter' target=_blank>Github</a>.
+                More information and documentation about our Jupyter Services can be found at
+                <a href='https://icos-carbon-portal.github.io/jupyter/' target=_blank>
+                    https://icos-carbon-portal.github.io/jupyter/</a>.
+			</p>
+			</div>
+	</td></tr>
+</table>
+
+{% endblock %}
+
+{% block script %}
+{{ super() }}
+<script>
+if (window.location.protocol === "http:") {
+  // unhide http warning
+  var warning = document.getElementById('insecure-login-warning');
+  warning.className = warning.className.replace(/\bhidden\b/, '');
+}
+// setup onSubmit feedback
+$('form').submit((e) => {
+  var form = $(e.target);
+  form.find('.feedback-container>input').attr('disabled', true);
+  form.find('.feedback-container>*').toggleClass('hidden');
+  form.find('.feedback-widget>*').toggleClass('fa-pulse');
+});
+</script>
+{% endblock %}

--- a/templates/jupyter/login.html
+++ b/templates/jupyter/login.html
@@ -1,0 +1,174 @@
+{% extends "page.html" %}
+{% if announcement_login %}
+  {% set announcement = announcement_login %}
+{% endif %}
+
+{% block login_widget %}
+{% endblock %}
+
+{% block main %}
+
+<style>
+table, th, td {
+  border: 0px solid black;
+  border-collapse: collapse;
+}
+th, td {
+  padding: 10px 30px;
+  vertical-align: top;
+}
+.btn-jupyter, .btn-jupyter:active, .btn-jupyter:active:hover, .btn-jupyter:active:focus,
+.btn-jupyter:focus { background-color: #00abc9; border-color: rgba(0,171,201,0.85); }
+.btn-jupyter:hover { background: rgba(0,171,201,0.85); border-color: rgba(0,171,201,0.85); }
+.btn-jupyter:active { filter: brightness(85%); }
+
+.info-txt{
+  font-size: 14px;
+  font-family: “Open Sans”,sans-serif;
+  max-width: 800px;
+}
+
+.header{
+  height: 150px;
+  width: 100%;
+}
+.header-top {
+  position: absolute;
+  height: 72px;
+  left: 100px;
+  top: 100px;
+  border: 0px solid black;
+  z-index: 1;
+ }
+</style>
+
+<div>
+	<img class='header'src='https://www.icos-cp.eu/themes/cp_theme_d8/images/icos-header.jpg'>
+	<a href="https://www.icos-cp.eu/" >
+		<img class='header-top'
+             src='https://www.icos-cp.eu/sites/default/files/ICOS-logo.svg' alt='Home'>
+	</a>
+</div>
+<br>
+<table>
+	<tr><td colspan="3">
+
+{% block login %}
+
+<div >
+<form action="{{login_url}}?next={{next}}" method="post" role="form">
+  <div class='info-txt'>
+    <p><h2>Sign in to Collaboration Server</h2></p>
+  </div>
+  <div class='auth-form-body'>
+
+    <p id='insecure-login-warning' class='hidden'>
+    Warning: JupyterHub seems to be served over an unsecured HTTP connection.
+    We strongly recommend enabling HTTPS for JupyterHub.
+    </p>
+    </td></tr>
+    <tr><td width= '40%'>
+    {% if login_error %}
+    <p class="login_error">
+      {{login_error}}
+    </p>
+    {% endif %}
+    <label for="username_input">Username:</label>
+    <input
+      id="username_input"
+      type="text"
+      autocapitalize="off"
+      autocorrect="off"
+      class="form-control"
+      name="username"
+      val="{{username}}"
+      tabindex="1"
+      autofocus="autofocus"
+    />
+    <label for='password_input'>Password:</label>
+    <input
+      type="password"
+      class="form-control"`
+      name="password"
+      id="password_input"
+      tabindex="2"
+    />
+    </td></tr>
+    <tr><td>
+    <input
+      type="checkbox"
+      name="licence"
+      id="licence_check"
+      onchange="document.getElementById('login_submit').disabled = !this.checked;"
+      tabindex="3"
+    />
+    <label for='licence'>
+    &nbsp I accept that ICOS data is under a<br>
+        <a href="https://data.icos-cp.eu/licence"
+           target="_blank">&nbsp CC BY 4.0 licence</a> &nbsp
+        <img src="https://www.icos-cp.eu/sites/default/files/inline-images/creativecommons.png">
+    </label>
+    </td><td>
+    <div class="feedback-container">
+      <input
+        id="login_submit"
+        type="submit"
+        class='btn btn-jupyter'
+        value='Sign In'
+        tabindex="4"
+        disabled='true'
+        />
+      <div class="feedback-widget hidden">
+        <i class="fa fa-spinner"></i>
+      </div>
+    </div>
+  </div>
+</form>
+
+</div>
+{% endblock login %}
+
+	</td>
+	<td width =200>&nbsp</td>
+	</tr>
+	<tr>
+	<td colspan="3">
+		<div class='info-txt'><p>
+		Our collaborative Jupyter Hub service is for <b>registered users</b> and offers advanced
+            options like<br></p>
+		<ul>
+			<li>sharing notebooks and data</li>
+			<li>uploading ancillary data for analysis together with ICOS data</li>
+			<li>permanent storage of notebooks and data</li>
+
+		</ul>
+		<p>This service is continuously expanded in close consultation with
+            our users and the ICOS community to support their scientific analysis and
+            interpretation of ICOS data and products. All data and notebooks are "private", hence
+            you can use this as a safe space to do research with unpublished data.</p>
+		<p>If you are interested in using our Jupyter Notebook Service to do research with ICOS
+            data and elaborated products, but you don't have an account yet, please send your
+            request to jupyter-info (at) icos-cp.eu .
+		</p></div>
+	</td></tr>
+</table>
+
+{% endblock %}
+
+{% block script %}
+{{ super() }}
+<script>
+if (window.location.protocol === "http:") {
+  // unhide http warning
+  var warning = document.getElementById('insecure-login-warning');
+  warning.className = warning.className.replace(/\bhidden\b/, '');
+}
+// setup onSubmit feedback
+$('form').submit((e) => {
+  var form = $(e.target);
+  form.find('.feedback-container>input').attr('disabled', true);
+  form.find('.feedback-container>*').toggleClass('hidden');
+  form.find('.feedback-widget>*').toggleClass('fa-pulse');
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
- Added different login templates for jupyter-hub and explore-data.
- Reworked templates' location within the repository. Each template is
  now in its own separated directory.
- Fixed minor spelling mistakes.
- Added the correct license to both templates.
- Reworked html code to match conventions.