### PR TITLE
zz fix pylib example notebook

### DIFF
--- a/notebooks/pylib_examples/ex2_station.ipynb
+++ b/notebooks/pylib_examples/ex2_station.ipynb
@@ -16,9 +16,9 @@
    "source": [
     "## Documentation\n",
     "Full documentation for the library on the",
-    "[project page](https://icos-carbon-portal.github.io/pylib/), how to install and wheel on",
-    "[pypi.org](https://pypi.org/project/icoscp/\"), source available on",
-    "[github](https://github.com/ICOS-Carbon-Portal/pylib)"
+    " [project page](https://icos-carbon-portal.github.io/pylib/), how to install and wheel on",
+    " [pypi.org](https://pypi.org/project/icoscp/\"), source available on",
+    " [github](https://github.com/ICOS-Carbon-Portal/pylib)"
    ]
   },
   {


### PR DESCRIPTION
- Fixed non-existent spacing between text and links.