### PR TITLE
pangaeapy - install from upstream git

### DIFF
--- a/docker/examples/content/ex3 - Combine ICOS & PANGAEA Data.ipynb
+++ b/docker/examples/content/ex3 - Combine ICOS & PANGAEA Data.ipynb
@@ -40,8 +40,6 @@
    "outputs": [],
    "source": [
     "# Import some standard libraries\n",
-    "import warnings                                                            \n",
-    "warnings.filterwarnings(\"ignore\", category=SyntaxWarning)\n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.colors as mcolors\n",
     "import folium\n",

--- a/docker/icosbase/content/pip_requirements.txt
+++ b/docker/icosbase/content/pip_requirements.txt
@@ -1,1 +1,1 @@
-pangaeapy @ git+https://github.com/pangaea-data-publisher
+pangaeapy @ git+https://github.com/pangaea-data-publisher/pangaeapy/

--- a/docker/icosbase/content/pip_requirements.txt
+++ b/docker/icosbase/content/pip_requirements.txt
@@ -1,1 +1,1 @@
-pangaeapy==1.1.0
+pangaeapy @ git+https://github.com/pangaea-data-publisher


### PR DESCRIPTION
Pins `pangaeapy` to the upstream git repository instead of the released `1.1.0`, and removes the now-unneeded `SyntaxWarning` suppression from the ex3 example notebook.
