### PR TITLE
fit-ic - add image variant with runtime TM5 clone

### DIFF
--- a/docker/fit-ic/build.fit-ic/Dockerfile
+++ b/docker/fit-ic/build.fit-ic/Dockerfile
@@ -1,0 +1,15 @@
+ARG BASE=registry.icos-cp.eu/stratos.icosbase:0.1.1
+FROM $BASE
+
+RUN uv pip install --system \
+    panel==1.8.10 \
+    param==2.3.3 \
+    hvplot==0.12.2 \
+    geoviews==1.15.1 \
+    holoviews==1.22.1 \
+    bokeh==3.9.0
+
+USER root
+COPY --chmod=0755 hooks/tm5-clone.sh /usr/local/bin/start-notebook.d/tm5-clone.sh
+USER ${NB_USER}
+ADD --chown=1000:100 content/. /home/jovyan/

--- a/docker/fit-ic/build.fit-ic/stratos_meta.json
+++ b/docker/fit-ic/build.fit-ic/stratos_meta.json
@@ -1,0 +1,7 @@
+{
+  "title": "fit-ic",
+  "description": "Based on icosbase, extended with the TM5 atmospheric transport model (cloned and installed at startup) and interactive visualization libraries (Panel, HoloViews, hvPlot, GeoViews, Bokeh).",
+  "licenses": [
+    "https://creativecommons.org/licenses/by/4.0/"
+  ]
+}

--- a/docker/fit-ic/content/fit_ic.ipynb
+++ b/docker/fit-ic/content/fit_ic.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ.setdefault('USER', 'jovyan')\n",
+    "\n",
+    "from tm5.gui.main import FitIC_UI\n",
+    "import panel as pn\n",
+    "pn.extension()\n",
+    "\n",
+    "x = FitIC_UI('/home/jovyan/gui.yml')\n",
+    "x"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docker/fit-ic/content/gui.yml
+++ b/docker/fit-ic/content/gui.yml
@@ -3,7 +3,7 @@ backend_url: http://pancake.nebula:5018
 emission_path: /data/avengers/fit_ic/input/emissions
 
 emissions:
-    glob_pattern: /data/avengers/fit_ic/emissions4inversion/fitic-*-emissions_*.nc
+    glob_pattern: /data/fit_ic/emissions4inversion*/fitic-*-emissions_*.nc
 
 observations:
   files: /data/avengers/fit_ic/observations/ch4_*.nc

--- a/docker/fit-ic/content/gui.yml
+++ b/docker/fit-ic/content/gui.yml
@@ -27,7 +27,7 @@ experiments:
 
 maxnproc: 4
 #-- loguru compliant loglevel (internal default is set to 'critical')
-loglevel: debug
+#loglevel: debug
 drop_precomputed : True
 #
 #-- statistics and comparison vs. observations

--- a/docker/fit-ic/content/gui.yml
+++ b/docker/fit-ic/content/gui.yml
@@ -1,0 +1,39 @@
+backend_url: http://pancake.nebula:5018
+
+emission_path: /data/avengers/fit_ic/input/emissions
+
+emissions:
+    glob_pattern: /data/avengers/fit_ic/emissions4inversion/fitic-*-emissions_*.nc
+
+observations:
+  files: /data/avengers/fit_ic/observations/ch4_*.nc
+
+experiments:
+  list:
+    default: fitic-simu-default_oh-cams/output_2021-01-01--2022-01-01
+    edgarflat: fitic-simu-edgarflat_oh-cams/output_2021-01-01--2022-01-01
+    regional: fitic-simu-regional_oh-cams/output_2021-01-01--2022-01-01
+    regional_no-agri: fitic-simu-regional_anthro-no-agri_oh-cams/output_2021-01-01--2022-01-01
+    regional_no-fossil: fitic-simu-regional_anthro-no-fossil_oh-cams/output_2021-01-01--2022-01-01
+    regional_no-waste: fitic-simu-regional_anthro-no-waste_oh-cams/output_2021-01-01--2022-01-01
+    regional_no-anthro-france: fitic-simu-regional_anthro-no-france_oh-cams/output_2021-01-01--2022-01-01
+    regional_no-anthro-netherlands: fitic-simu-regional_anthro-no-netherlands_oh-cams/output_2021-01-01--2022-01-01
+    half-oh: fitic-simu-half-oh_oh-cams/output_2021-01-01--2022-01-01
+    no-germany: fitic-simu-no-germany_oh-cams/output_2021-01-01--2022-01-01
+    no-gns: fitic-simu-no-gns_oh-cams/output_2021-01-01--2022-01-01
+    no-northamerica: fitic-simu-no-northamerica_oh-cams/output_2021-01-01--2022-01-01
+  path:  /data/fit_ic_workshop/precomputed_output
+  cache: /home/jovyan/experiments_cache
+
+maxnproc: 4
+#-- loguru compliant loglevel (internal default is set to 'critical')
+loglevel: debug
+drop_precomputed : True
+#
+#-- statistics and comparison vs. observations
+#
+statistics:
+  selected_hours : True #-- otherwise all obs will enter in statistics
+  high_altitude : 1000.
+  hours_high_alt : ['00:00','04:00']
+  hours_low_alt  : ['12:00','16:00']

--- a/docker/fit-ic/hooks/tm5-clone.sh
+++ b/docker/fit-ic/hooks/tm5-clone.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+TARGET="/home/jovyan/tm5"
+REPO="https://github.com/gmonteil/tm5.git"
+BRANCH="ilab"
+
+if [[ -d "$TARGET" ]]; then
+    echo "tm5-clone: $TARGET already present, skipping clone"
+else
+    echo "tm5-clone: cloning $REPO ($BRANCH) into $TARGET..."
+    git clone --branch "$BRANCH" "$REPO" "$TARGET"
+fi
+
+echo "tm5-clone: installing $TARGET in editable mode..."
+uv pip install --system -e "$TARGET"


### PR DESCRIPTION
New `fit-ic` image under `docker/fit-ic/`, built on `icosbase 0.1.1`.

Adds: 
  - **Interactive viz stack:** Panel, hvPlot, GeoViews, HoloViews, Bokeh
  - **`fit_ic.ipynb`** notebook
  - **`gui.yml`** config: backend URL, data paths, experiment list

A startup hook (`hooks/tm5-clone.sh`) clones [`gmonteil/tm5@ilab`](https://github.com/gmonteil/tm5/tree/ilab) into `/home/jovyan/tm5` and installs it editable (`uv pip install -e`) on container start. Keeps the image lean and lets the model code track `ilab` without a rebuild.